### PR TITLE
update variable sample_rate to sr

### DIFF
--- a/chapter6/Chapter 6.ipynb
+++ b/chapter6/Chapter 6.ipynb
@@ -297,7 +297,7 @@
     "def precompute_spectrograms(path, dpi=50):\n",
     "    files = Path(path).glob('*.wav')\n",
     "    for filename in files:\n",
-    "        audio_tensor, sample_rate = librosa.load(filename, sr=None)\n",
+    "        audio_tensor, sr = librosa.load(filename, sr=None)\n",
     "        spectrogram = librosa.feature.melspectrogram(audio_tensor, sr=sr)\n",
     "        log_spectrogram = librosa.power_to_db(spectrogram, ref=np.max)\n",
     "        librosa.display.specshow(log_spectrogram, sr=sr, x_axis='time', y_axis='mel')\n",


### PR DESCRIPTION
On line 300 the variable sample_rate should be changed to sr.  In the function librosa.load, sr=None allows us to use the native sample rate of the audio file being examined, but currently we are ignoring that sample rate due to a mismatch in variable names.  Prior to this function sr is defined on line 286 so every file is using that sample rate.  Assuming all files are using the same sample rate this is ok, but probably not what you were intending to do as unused variables are often saved to "_" to show they are unused.

Making this change would allow the following line's function librosa.feature.melspectrogram to properly use the native sample rate which was determined when sr=None in the pervious function.