### PR TITLE
add numpy as np import

### DIFF
--- a/chapter6/Chapter 6.ipynb
+++ b/chapter6/Chapter 6.ipynb
@@ -24,6 +24,7 @@
     "from torchvision import models\n",
     "import torchvision\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "import librosa\n",
     "import librosa.display\n",
     "import random\n",


### PR DESCRIPTION
added import of numpy as np for converting our audio wav forms to images.  librosa.power_to_db's keyword argument ref uses callable function np.max.  Without this, the code will error out with; "name 'np' is not defined"